### PR TITLE
Add trails JSON API

### DIFF
--- a/app/controllers/trails_controller.rb
+++ b/app/controllers/trails_controller.rb
@@ -3,11 +3,29 @@ class TrailsController < ApplicationController
 
   def index
     @trails = Trail.all
+    respond_to do |format|
+      format.html
+      format.json { render json: { trails: serialize_trails(@trails) } }
+    end
   end
 
   def show
     @trail = Trail.find(params[:id])
     @review = Review.new
     @reviews = Review.where(trail: @trail)
+  end
+
+  private
+
+  def serialize_trails(trails)
+    trails.map do |trail|
+      {
+        name: trail.name,
+        difficulty: trail.difficulty,
+        type: trail.category,
+        zone: trail.zone,
+        start: [trail.start_lng, trail.start_lat]
+      }
+    end
   end
 end

--- a/app/models/trail.rb
+++ b/app/models/trail.rb
@@ -6,8 +6,7 @@ class Trail < ApplicationRecord
   validates :name, presence: true
   validates :difficulty, presence: true, inclusion: { in: %w(beginner intermediate advanced expert proline) }
   validates :category, presence: true, inclusion: { in: %w(freeride technical) }
+  validates :zone, presence: true, inclusion: { in: ['Fitzsimmons Zone', 'Garbanzo Zone', 'Creekside Zone', 'Peak Zone'] }
   validates :start_lat, presence: true
   validates :start_lng, presence: true
-  validates :end_lat, presence: true
-  validates :end_lng, presence: true
 end

--- a/db/migrate/20210826140010_add_zone_to_trails.rb
+++ b/db/migrate/20210826140010_add_zone_to_trails.rb
@@ -1,0 +1,7 @@
+class AddZoneToTrails < ActiveRecord::Migration[6.0]
+  def change
+    add_column :trails, :zone, :string
+    remove_column :trails, :end_lat, :float
+    remove_column :trails, :end_lng, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_19_052813) do
+ActiveRecord::Schema.define(version: 2021_08_26_140010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,8 +72,7 @@ ActiveRecord::Schema.define(version: 2021_06_19_052813) do
     t.datetime "updated_at", precision: 6, null: false
     t.float "start_lat"
     t.float "start_lng"
-    t.float "end_lat"
-    t.float "end_lng"
+    t.string "zone"
     t.index ["mountain_id"], name: "index_trails_on_mountain_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -42,30 +42,19 @@ dataset_url = "https://api.mapbox.com/datasets/v1/andycalder/#{dataset_id}/featu
 dataset = URI.open(dataset_url).read
 trails = JSON.parse(dataset)['features']
 
-def difficulty(color)
-  case color
-  when 'green' then 'beginner'
-  when 'blue' then 'intermediate'
-  when 'black' then 'advanced'
-  when 'doubleblack' then 'expert'
-  when 'red' then 'proline'
-  end
-end
-
 trails.each do |trail|
   props = trail['properties']
   coords = trail['geometry']['coordinates']
 
-  unless props['type'] == 'chairlift' || trail['geometry']['type'] == 'Point'
+  if props['type'] && %w(technical freeride).include?(props['type'])
     record = Trail.new(
       mountain: whistler,
       name: props['name'],
-      difficulty: difficulty(props['difficulty']) || 'beginner',
-      category: props['type'] ? 'freeride' : 'technical',
+      difficulty: props['difficulty'],
+      category: props['type'],
+      zone: props['zone'],
       start_lat: coords.first[1],
-      start_lng: coords.first[0],
-      end_lat: coords.last[1],
-      end_lng: coords.last[0]
+      start_lng: coords.first[0]
     )
 
     if record.valid?


### PR DESCRIPTION
Hey guys, I've been experimenting with a mobile-friendly react front end and I need the trail data in JSON format. This PR adds a JSON API so you can easily access the trail data. 

Just send a GET request to `/mountains/1/trails` with the `accept: 'application/json'` HTTP header and you'll get a JSON response:
```
fetch('https://www.mountain-maps.com/mountains/1/trails', { headers: { accept: 'application/json' } })
  .then(response => response.json()).
  .then(data => console.log(data));
```

- [x] Add `zone` column to `Trail`.
- [x] Remove unnecessary `end_lat` and `end_lng` columns from `Trail`.
- [x] Update `seeds.rb`.
- [x] Add JSON endpoint to `mountains/1/trails`.